### PR TITLE
Fix incorrect web service name if additional XML attributes are provided

### DIFF
--- a/src/devtools/util.js
+++ b/src/devtools/util.js
@@ -21,6 +21,7 @@ var self = module.exports = {
   getWebServiceName: async (xml) => {
     return new Promise((resolve, reject) => {
       const parseConfig = {
+        ignoreAttrs: true,
         tagNameProcessors: [stripPrefix]
       };
       parseString(xml, parseConfig, (err, result) => {


### PR DESCRIPTION
If a method call of a webservice needs additional xml attributes the name of the web service is not recognized correctly and only `$` is displayed instead of the actual method name.

Example request:
```xml
<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
  <s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
    <keepAlive xmlns="...." xmlns:ns1="....">
       ...
    </keepAlive>
  </s:Body>
</s:Envelope>
```